### PR TITLE
Remove auto publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,12 +24,3 @@ workflows:
   publish:
     jobs:
     - publish_images
-  auto_publish:
-    triggers:
-      - schedule:
-          cron: "0 0 * * 0"
-          filters:
-            branches:
-              only: master
-    jobs:
-      - publish_images


### PR DESCRIPTION
Publishing is broken because of Docker hub credentials being cleaned up, and this still using Noam's credentials. The build in this PR also breaks for the same reason, but at least now it won't be something that happens on a regular basis. 